### PR TITLE
SDK Core tests and related changes

### DIFF
--- a/ggcore/core.py
+++ b/ggcore/core.py
@@ -19,15 +19,15 @@ class SdkCore:
 
         self._setup_clients()
 
-    def _setup_clients(self, ):
+    def _setup_clients(self):
         """Setup low-level clients."""
         self._config_client = ConfigClient(self._configuration)
         self._nlp_client = NlpClient(self._configuration)
 
     # test purposes only
-    def test_api(self):
+    def test_api(self, test_message=None):
         """Execute test call."""
-        return self._config_client.test_api()
+        return self._config_client.test_api(test_message)
 
     def save_dataset(self, generator: typing.Generator, dataset_id: str,
                      overwrite: bool):
@@ -37,6 +37,7 @@ class SdkCore:
                                              overwrite=overwrite)
 
     def promote_model(self, model_name: str, nlp_task: str, environment: str):
+        """Execute promote model call."""
         return self._nlp_client.promote_model(model_name=model_name,
                                               nlp_task=nlp_task,
                                               environment=environment)

--- a/ggcore/http_base.py
+++ b/ggcore/http_base.py
@@ -19,7 +19,11 @@ class SdkHttpClient:
         sdk_response.response = http_response.content.decode()
 
         try:
+            # raise exception if one occurred
             http_response.raise_for_status()
+
+            # otherwise, set exception to None
+            sdk_response.exception = None
         except requests.RequestException as request_exception:
             sdk_response.exception = request_exception
 

--- a/ggcore/sdk_messages.py
+++ b/ggcore/sdk_messages.py
@@ -1,6 +1,7 @@
 """Define classes for sdk service request/response objects."""
 
 import dataclasses
+import json
 import typing
 from dataclasses import dataclass
 
@@ -113,9 +114,20 @@ class SdkServiceRequest:
         for key, value in header_dict.items():
             self.add_header(key, value, overwrite)
 
+    def __eq__(self, other):
+        if isinstance(other, SdkServiceRequest):
+            return self._url == other._url \
+                   and self._headers == other._headers \
+                   and self._body == other._body \
+                   and self._api_endpoint == other._api_endpoint \
+                   and self._http_method == other._http_method \
+                   and self._query_params == other._query_params \
+                   and self._api_response_handler == self._api_response_handler
+        return False
+
 
 # pylint: disable=too-few-public-methods
-class SavaDatasetResponse(SdkServiceResponse):
+class SaveDatasetResponse(SdkServiceResponse):
     """Define class representing a save dataset api call response."""
     dataset_id: str = None
     save_path: str = None
@@ -130,6 +142,7 @@ class PromoteModelResponse(SdkServiceResponse):
 
 class PropertySource:
     """Define class representing a source of name/value property pairs."""
+
     def __init__(self, name: str, source: typing.Dict[typing.Any, typing.Any]):
         self.name = name
         self.source = source
@@ -138,6 +151,7 @@ class PropertySource:
 # pylint: disable=too-many-arguments
 class GetDataResponse(SdkServiceResponse):
     """Define class representing the enviornment response from get data."""
+
     def __init__(self, name: str, profiles: typing.List[str], label: str,
                  property_sources: typing.List[PropertySource], version: str,
                  state: str):
@@ -148,3 +162,17 @@ class GetDataResponse(SdkServiceResponse):
                                  property_source in property_sources]
         self.version = version
         self.state = state
+
+
+class TestApiResponse(SdkServiceResponse):
+    """Define class representing a test api call response."""
+    response_str: str = None
+
+    # better way to populate? will all responses have to do this?
+    def __init__(self, sdk_response: SdkServiceResponse):
+        self.response = sdk_response.response
+        self.status_text = sdk_response.status_text
+        self.status_code = sdk_response.status_code
+        self.exception = sdk_response.exception
+
+        self.response_str = json.loads(self.response)["content"]

--- a/ggsdk/sdk.py
+++ b/ggsdk/sdk.py
@@ -1,10 +1,10 @@
 """Define user-facing GraphGrid SDK."""
 import typing
-import json
 
 from ggcore.config import SdkBootstrapConfig
 from ggcore.core import SdkCore
-from ggcore.sdk_messages import GetDataResponse
+from ggcore.sdk_messages import TestApiResponse, SaveDatasetResponse, \
+    GetDataResponse
 
 
 class GraphGridSdk:
@@ -24,14 +24,18 @@ class GraphGridSdk:
     def _setup_core(self):
         self._core = SdkCore(self._config)
 
-    def test_api(self):
-        """Call test api."""
-        return self._core.test_api()
+    def test_api(self,
+                 message: str = None) -> TestApiResponse:
+        """Call test api.
+
+        :param message:  The test message that is both send and received
+        """
+        return self._core.test_api(message)
 
     def save_dataset(self,
                      data_generator: typing.Generator,
                      dataset_id: str = None,
-                     overwrite=False):
+                     overwrite=False) -> SaveDatasetResponse:
         """Call save dataset api.
 
         :param data_generator:  The generator providing dataset lines
@@ -39,7 +43,7 @@ class GraphGridSdk:
         :param overwrite:   Whether to overwrite the dataset if it already
             exists (default=False)
         """
-        self._core.save_dataset(data_generator, dataset_id, overwrite)
+        return self._core.save_dataset(data_generator, dataset_id, overwrite)
 
     def promote_model(self, model_name: str, nlp_task: str,
                       environment: str = "default"):
@@ -53,7 +57,7 @@ class GraphGridSdk:
 
     def get_data(self, module: str,
                  profiles: typing.Union[str, typing.List[str]],
-                 revision: str):
+                 revision: str) -> GetDataResponse:
         """Call get data api.
 
         :param module: Name of the module for the spring param path, e.g., nlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pytest-cov==2.10.0
 pylint==2.7.4
 coverage2clover==3.3.0
 requests~=2.27.1
+responses==0.20.0
 setuptools~=57.0.0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,19 @@
+"""Define test base classes used throughout the tests."""
+from unittest import TestCase
+
+from ggcore.config import SdkBootstrapConfig, SdkSecurityConfig
+
+
+class TestBootstrapBase(TestCase):
+    """Define base for tests that contains the bootstrap config and test
+    credentials.
+    """
+
+    TEST_TOKEN: str = "test-token"
+
+    _test_bootstrap_config = SdkBootstrapConfig(
+        access_key='a3847750f486bd931de26c6e683b1dc4',
+        secret_key='81a62cea53883f4a163a96355d47656e',
+        url_base='localhost')
+
+    _test_credentials = SdkSecurityConfig(_test_bootstrap_config, TEST_TOKEN)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,85 @@
+"""Define test classes for testing client-level features."""
+from unittest.mock import patch
+
+import ggcore.http_base
+from ggcore.api import ConfigApi, AbstractApi
+from ggcore.client import ConfigClient
+from ggcore.sdk_messages import SdkServiceRequest
+from ggcore.security_base import SdkAuthHeaderBuilder
+from ggcore.utils import HttpMethod
+from tests.test_base import TestBootstrapBase
+
+
+class TestClientBase(TestBootstrapBase):
+    """Define test base for client-level tests."""
+
+
+class TestClientSdkRequestBuilding(TestClientBase):
+    """Define test class for grouping client-level sdk request building."""
+
+    # pylint: disable=unused-argument
+    @patch.object(ggcore.security_base.BearerAuth, "get_auth_value",
+                  return_value=TestBootstrapBase.TEST_TOKEN)
+    @patch.object(ggcore.client.SecurityClient, "is_token_present",
+                  return_value="true")
+    def test_client_feature__build_sdk_request__test_api(self,
+                                                         mock_get_auth_value,
+                                                         mock_is_token_present):
+        """Test that client can properly construct test api sdk request from
+        TestApi definition.
+        """
+
+        # get TestApi definition
+        test_api = ConfigApi.test_api()
+
+        # setup config client
+        config_client = ConfigClient(self._test_bootstrap_config)
+
+        # setup expected service request
+        expected = SdkServiceRequest()
+        expected.http_method = HttpMethod.GET
+        expected.api_endpoint = "config/this/is/a/test"
+        expected.headers = AbstractApi().headers()
+        expected.add_headers(SdkAuthHeaderBuilder.get_bearer_header(
+            self._test_credentials))
+        expected.query_params = {}
+        expected.body = {}
+        expected.api_response_handler = AbstractApi().handler
+        expected.url = f'http://localhost/1.0/{expected.api_endpoint}'
+
+        # build actual service request from api definition
+        actual = config_client.build_sdk_request(test_api)
+
+        # assert actual request equals expected request
+        assert actual == expected
+
+    def test_client_feature__build_sdk_request__save_dataset(self):
+        """Test client properly constructs save dataset sdk request from
+        SaveDatasetApi definition.
+        """
+
+    def test_client_feature__build_sdk_request__get_data(self):
+        """Test client properly constructs get data sdk request from
+        GetDataApi definition.
+        """
+
+    def test_client_feature__build_sdk_request__promote_model(self):
+        """Test client properly constructs promote model sdk request from
+        PromoteModelApi definition.
+        """
+
+
+class TestClientGenericResponseHandling(TestClientBase):
+    """Define test class for grouping client-level generic response handling."""
+
+    def test_client_feature__generic_response_handling__500(self):
+        """Test built-in client ability to handle 500 Internal Server Error."""
+
+    def test_client_feature__generic_response_handling__401(self):
+        """Test built-in client ability to handle 401 Unauthorized.
+
+        This test covers:
+            (1) token handling grabs a new token after a 401 Unauthorized.
+            (2) 401 Unauthorized are retried automatically.
+            (3) A subsequent 401 returns a response with an error.
+        """

--- a/tests/test_ggsdk.py
+++ b/tests/test_ggsdk.py
@@ -1,4 +1,0 @@
-# Sdk test ideas. Handling expected scenarios of what boot-nlp will give
-# back. Can test sdk calls by creating an obj we know the request/response
-# should look like, then running the code to create those request/response
-# and checking them against each other.

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,86 @@
+"""Define test classes for testing user-facing sdk calls."""
+import json
+from unittest.mock import patch
+
+import responses
+
+import ggcore
+import ggsdk.sdk
+from ggcore.api import ConfigApi
+from ggcore.sdk_messages import TestApiResponse, SdkServiceResponse
+from tests.test_base import TestBootstrapBase
+
+
+class TestSdkBase(TestBootstrapBase):
+    """Define test base specifically for high-level sdk calls."""
+
+
+class TestSdkTestApi(TestSdkBase):
+    """Define test class for TestApi sdk calls."""
+
+    # pylint: disable=unused-argument
+    @responses.activate  # mock responses
+    @patch.object(ggcore.security_base.BearerAuth, "get_auth_value",
+                  return_value=TestBootstrapBase.TEST_TOKEN)
+    @patch.object(ggcore.client.SecurityClient, "is_token_present",
+                  return_value="true")
+    def test_sdk_call__test_api__200(self, mock_get_auth_value,
+                                     mock_is_token_present):
+        """Test sdk TestApi call when response is 200 OK.
+
+        Test that the GraphGridSdk.test_api() call sets up correct sdk
+        request and can handle responses properly.
+
+        Works by mocking http response and ensure we get back the expected
+        TestApiResponse.
+        """
+
+        # setup expected message and json body for test
+        expected_message = "pass me back and forth"
+        json_body = {"content": expected_message}
+
+        # setup sdk
+        sdk = ggsdk.sdk.GraphGridSdk(self._test_bootstrap_config.access_key,
+                                     self._test_bootstrap_config.secret_key,
+                                     self._test_bootstrap_config.url_base)
+
+        # setup responses mock
+        responses.add(responses.GET,
+                      f'http://localhost/1.0/config/'
+                      f'{ConfigApi.test_api().endpoint()}',
+                      json=json_body, status=200)
+
+        # setup expected TestApiResponse obj
+        expected_response = TestApiResponse(
+            SdkServiceResponse(200, "OK", json.dumps(json_body), None))
+
+        # call sdk method for test api
+        actual_response: TestApiResponse = sdk.test_api(expected_message)
+
+        # assert that the TestApiResponse returned is the same as the
+        # expected response
+        assert actual_response == expected_response
+
+
+class TestSdkSaveDataset(TestSdkBase):
+    """Define test class for SaveDatasetApi sdk calls."""
+
+    def test_sdk_call__save_dataset__200(self):
+        """Test sdk SaveDataset call when response is 200 OK."""
+
+    def test_sdk_call__save_dataset__409(self):
+        """Test sdk SaveDatasetApi call when response is 409 Conflict."""
+
+
+class TestSdkGetData(TestSdkBase):
+    """Define test class for GetDataApi sdk calls."""
+
+    def test_sdk_call__get_data__200(self):
+        """Test sdk GetDataApi call when response is 200 OK."""
+
+
+class TestSdkPromoteModel(TestSdkBase):
+    """Define test class for PromoteModelApi sdk calls."""
+
+    def test_sdk_call__promote_model__200(self):
+        """Test sdk PromoteModelApi call when response is 200 OK."""


### PR DESCRIPTION
Add SDK core tests and related SDK core fixes/refactors.

* Add sdk test classes test_base, test_client, test_sdk.

* Adds test scaffolding.

* Extends TestApi to have message string for testing purposes.

* Add 'responses==0.20.0' to requirements.txt.

* Implement build_sdk_request. Decouple sdk request building from sdk request invoking.

* Link up SaveDataset sdk call to return SaveDatasetResponse.