### PR TITLE
2.0 - bug - Fix SdkServiceResponse 

### DIFF
--- a/ggcore/client.py
+++ b/ggcore/client.py
@@ -6,7 +6,8 @@ from ggcore.api import SecurityApi, SdkRequestBuilder, NlpApi, ConfigApi, \
     AbstractApi
 from ggcore.config import SdkBootstrapConfig, SdkSecurityConfig
 from ggcore.http_base import SdkHttpClient
-from ggcore.sdk_messages import SdkServiceResponse, SdkServiceRequest
+from ggcore.sdk_messages import SdkServiceResponse, SdkServiceRequest, \
+    GetTokenResponse
 from ggcore.security_base import SdkAuthHeaderBuilder
 from ggcore.session import TokenFactory
 from ggcore.utils import DOCKER_NGINX_PORT
@@ -71,7 +72,8 @@ class SecurityClient(ClientBase):
             self._security_config)
         sdk_request.headers.update(auth_basic_header)
 
-        token = self.make_request(sdk_request)
+        get_token_response: GetTokenResponse = self.make_request(sdk_request)
+        token = get_token_response.access_token
 
         self._security_config.token = token
 

--- a/ggcore/http_base.py
+++ b/ggcore/http_base.py
@@ -1,8 +1,7 @@
 """Define classes for building, executing, processing http requests."""
 import requests
 
-from ggcore.sdk_messages import SdkServiceRequest
-from ggcore.sdk_messages import SdkServiceResponse
+from ggcore.sdk_messages import SdkServiceRequest, SdkResponseHelper
 
 
 class SdkHttpClient:
@@ -11,7 +10,7 @@ class SdkHttpClient:
     @classmethod
     def http_response_to_sdk_response(cls, http_response: requests.Response):
         """Build an SdkServiceResponse from the http response."""
-        sdk_response = SdkServiceResponse()
+        sdk_response = SdkResponseHelper()
 
         sdk_response.status_code = http_response.status_code
 
@@ -32,7 +31,7 @@ class SdkHttpClient:
 
     @classmethod
     def execute_request(cls,
-                        sdk_request: SdkServiceRequest) -> SdkServiceResponse:
+                        sdk_request: SdkServiceRequest) -> SdkResponseHelper:
         """Build and execute http request."""
         http_response: requests.Response = requests.request(
             method=sdk_request.http_method.value,
@@ -41,7 +40,7 @@ class SdkHttpClient:
             data=sdk_request.body,
             headers=sdk_request.headers)
 
-        sdk_response: SdkServiceResponse = cls.http_response_to_sdk_response(
+        sdk_response: SdkResponseHelper = cls.http_response_to_sdk_response(
             http_response)
         return sdk_response
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -7,7 +7,7 @@ import responses
 import ggcore
 import ggsdk.sdk
 from ggcore.api import ConfigApi
-from ggcore.sdk_messages import TestApiResponse, SdkServiceResponse
+from ggcore.sdk_messages import TestApiResponse, SdkResponseHelper
 from tests.test_base import TestBootstrapBase
 
 
@@ -52,7 +52,7 @@ class TestSdkTestApi(TestSdkBase):
 
         # setup expected TestApiResponse obj
         expected_response = TestApiResponse(
-            SdkServiceResponse(200, "OK", json.dumps(json_body), None))
+            SdkResponseHelper(200, "OK", json.dumps(json_body), None))
 
         # call sdk method for test api
         actual_response: TestApiResponse = sdk.test_api(expected_message)


### PR DESCRIPTION
Adds SdkResponseHelper as an inbetween class for HTTP response and SdkServiceResponse. Changes over all handlers and sdk response subclasses to use SdkResponseHelper.

This fixes an issue where SdkServiceResponse subclasses couldn't properly populate the superclasses fields when building the sdk response objects in the API handler methods.  