### PR TITLE
jobResults endpoint from /result/ to /results/

### DIFF
--- a/graphgrid_sdk/ggcore/api.py
+++ b/graphgrid_sdk/ggcore/api.py
@@ -281,7 +281,7 @@ class NlpApi(ApiGroup):
             return NLP
 
         def endpoint(self):
-            return f"result/{self._dag_id}/{self._dag_run_id}"
+            return f"results/{self._dag_id}/{self._dag_run_id}"
 
         def http_method(self) -> HttpMethod:
             return HttpMethod.GET


### PR DESCRIPTION
endpoint change reflected in [boot-common PR](https://bitbucket.org/graphgrid/graphgrid-boot-common/pull-requests/194/20-savelocation)