### PR TITLE
2.0 get active model

### DIFF
--- a/graphgrid_sdk/ggcore/api.py
+++ b/graphgrid_sdk/ggcore/api.py
@@ -7,7 +7,7 @@ from graphgrid_sdk.ggcore.sdk_messages import SdkServiceResponse, \
     SdkServiceRequest, GetDataResponse, TestApiResponse, SaveDatasetResponse, \
     GenericResponse, GetTokenResponse, CheckTokenResponse, \
     PromoteModelResponse, DagRunResponse, NMTStatusResponse, \
-    NMTTrainResponse, TrainRequestBody
+    NMTTrainResponse, TrainRequestBody, GetActiveModelResponse
 from graphgrid_sdk.ggcore.utils import CONFIG, SECURITY, NLP, HttpMethod, \
     GRANT_TYPE_KEY, GRANT_TYPE_CLIENT_CREDENTIALS, CONTENT_TYPE_HEADER_KEY, \
     CONTENT_TYPE_APP_JSON, USER_AGENT, CONTENT_TYPE_APP_X_WWW_FORM_URLENCODED
@@ -217,6 +217,11 @@ class NlpApi(ApiGroup):
         """Return nmt train api."""
         return cls.NmtTrainApi(request_body)
 
+    @classmethod
+    def get_active_model_api(cls, nlp_task: str):
+        """Return get active model api."""
+        return cls.GetActiveModelApi(nlp_task)
+
     @dataclass
     class SaveDatasetApi(AbstractApi):
         """Define SaveDatasetApi api."""
@@ -264,7 +269,7 @@ class NlpApi(ApiGroup):
             return NLP
 
         def endpoint(self):
-            return f"promoteModel/{self._environment}/{self._nlp_task}/{self._model_name}"
+            return f"promoteModel/{self._environment}/{self._model_name}"
 
         def http_method(self) -> HttpMethod:
             return HttpMethod.POST
@@ -361,6 +366,26 @@ class NlpApi(ApiGroup):
 
         def handler(self, generic_response: GenericResponse):
             return NMTTrainResponse(generic_response)
+
+    @dataclass
+    class GetActiveModelApi(AbstractApi):
+        """Define GetActiveModelApi api."""
+        _nlp_task: str
+
+        def __init__(self, nlp_task: str):
+            self._nlp_task = nlp_task
+
+        def api_base(self) -> str:
+            return NLP
+
+        def endpoint(self):
+            return f"getActiveModel/{self._nlp_task}"
+
+        def http_method(self) -> HttpMethod:
+            return HttpMethod.GET
+
+        def handler(self, generic_response: GenericResponse):
+            return GetActiveModelResponse(generic_response)
 
 
 class SdkRequestBuilder:

--- a/graphgrid_sdk/ggcore/api.py
+++ b/graphgrid_sdk/ggcore/api.py
@@ -269,7 +269,7 @@ class NlpApi(ApiGroup):
             return NLP
 
         def endpoint(self):
-            return f"promoteModel/{self._environment}/{self._model_name}"
+            return f"promoteModel/{self._environment}/{self._nlp_task}/{self._model_name}"
 
         def http_method(self) -> HttpMethod:
             return HttpMethod.POST

--- a/graphgrid_sdk/ggcore/client.py
+++ b/graphgrid_sdk/ggcore/client.py
@@ -248,3 +248,8 @@ class NlpClient(SecurityClientBase):
         """Return job train sdk call."""
         api_call = NlpApi.nmt_train_api(request_body)
         return self.invoke(api_call)
+
+    def get_active_model(self, nlp_task: str):
+        """Return get active model sdk call."""
+        api_call = NlpApi.get_active_model_api(nlp_task)
+        return self.invoke(api_call)

--- a/graphgrid_sdk/ggcore/core.py
+++ b/graphgrid_sdk/ggcore/core.py
@@ -70,3 +70,7 @@ class SdkCore:
     def nmt_train(self, request_body: TrainRequestBody) -> NMTTrainResponse:
         """Execute nmt train call."""
         return self._nlp_client.trigger_nmt(request_body)
+
+    def get_active_model(self, nlp_task: str):
+        """Execute get active model call."""
+        return self._nlp_client.get_active_model(nlp_task=nlp_task)

--- a/graphgrid_sdk/ggcore/sdk_messages.py
+++ b/graphgrid_sdk/ggcore/sdk_messages.py
@@ -325,5 +325,5 @@ class GetActiveModelResponse(SdkServiceResponse):
 
         if self.status_code == 200:
             loaded: dict = json.loads(generic_response.response)
-            self.dag_run_id = loaded.get('modelName')
-            self.logical_date = loaded.get('trainedModelData')
+            self.model_name = loaded.get('modelName')
+            self.trained_model_data = loaded.get('trainedModelData')

--- a/graphgrid_sdk/ggcore/sdk_messages.py
+++ b/graphgrid_sdk/ggcore/sdk_messages.py
@@ -314,3 +314,13 @@ class TrainRequestBody:
     def to_json(self):
         """Encode TrainRequestBody to a json object"""
         return json.dumps(self.__dict__, indent=4)
+
+
+class GetActiveModelResponse(SdkServiceResponse):
+    """Define class representing a get active model api call response."""
+    task: str
+
+    def __init__(self, generic_response: GenericResponse):
+        super().__init__(generic_response)
+
+        self.task = generic_response.response

--- a/graphgrid_sdk/ggcore/sdk_messages.py
+++ b/graphgrid_sdk/ggcore/sdk_messages.py
@@ -318,12 +318,13 @@ class TrainRequestBody:
 
 class GetActiveModelResponse(SdkServiceResponse):
     """Define class representing a get active model api call response."""
-    task: str
+    modelName: str
+    trainedModelData: dict
 
     def __init__(self, generic_response: GenericResponse):
         super().__init__(generic_response)
 
         if self.status_code == 200:
             loaded: dict = json.loads(generic_response.response)
-            self.model_name = loaded.get('modelName')
-            self.trained_model_data = loaded.get('trainedModelData')
+            self.modelName = loaded.get('modelName')
+            self.trainedModelData = loaded.get('trainedModelData')

--- a/graphgrid_sdk/ggcore/sdk_messages.py
+++ b/graphgrid_sdk/ggcore/sdk_messages.py
@@ -323,4 +323,7 @@ class GetActiveModelResponse(SdkServiceResponse):
     def __init__(self, generic_response: GenericResponse):
         super().__init__(generic_response)
 
-        self.task = generic_response.response
+        if self.status_code == 200:
+            loaded: dict = json.loads(generic_response.response)
+            self.dag_run_id = loaded.get('modelName')
+            self.logical_date = loaded.get('trainedModelData')

--- a/graphgrid_sdk/ggsdk/sdk.py
+++ b/graphgrid_sdk/ggsdk/sdk.py
@@ -96,3 +96,10 @@ class GraphGridSdk:
         :param request_body: Training config.
         """
         return self._core.nmt_train(request_body)
+
+    def get_active_model(self, nlp_task: str):
+        """Call get active model api.
+
+        :param nlp_task: The associated NLP task for the desired model
+        """
+        return self._core.get_active_model(nlp_task)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -11,7 +11,7 @@ from graphgrid_sdk.ggcore.api import ConfigApi, NlpApi
 from graphgrid_sdk.ggcore.sdk_messages import TestApiResponse, \
     GenericResponse, SaveDatasetResponse, PromoteModelResponse, \
     GetDataResponse, DagRunResponse, NMTTrainResponse, NMTStatusResponse, \
-    TrainRequestBody
+    TrainRequestBody, GetActiveModelResponse
 from graphgrid_sdk.ggcore.session import TokenTracker, TokenFactory
 from graphgrid_sdk.ggsdk import sdk
 from graphgrid_sdk.ggsdk.sdk import GraphGridSdk
@@ -193,6 +193,46 @@ class TestSdkPromoteModel(TestSdkBase):
         actual_response: PromoteModelResponse = gg_sdk.promote_model(
             model_name=model_name, nlp_task=nlp_task,
             environment=environment)
+
+        assert actual_response == expected_response
+
+
+class TestSdkGetActiveModel(TestSdkBase):
+    """Define test class for PromoteModelApi sdk calls."""
+
+    @responses.activate  # mock responses
+    @patch.object(TokenFactory, "_token_tracker",
+                  TokenTracker(TestBase.TEST_TOKEN, 10_000))
+    def test_sdk_call__get_active_model__200(self):
+        """Test sdk GetActiveModelApi call when response is 200 OK."""
+        model_name = "any_model"
+        nlp_task = "some_task"
+        expected_trained_model_data_dict = {
+            "modelType": nlp_task,
+            "trainingDataset": ["sdk"],
+            "trainingAccuracy": 0.842,
+            "trainingLoss": 0.145,
+            "evalAccuracy": None,
+            "evalLoss": None,
+            "properties": {"languages": ["en"]},
+            "location": "someSavedModelLocationUrl",
+            "timestamp": "2022-04-20T20:31:33",
+            "platformVersion": "2.0.0"
+        }
+        expected_response_dict = {
+            "modelName": model_name,
+            "trainedModelData": expected_trained_model_data_dict
+        }
+
+        # setup sdk
+        gg_sdk = sdk.GraphGridSdk(self._test_bootstrap_config)
+        responses.add(method=responses.GET,
+                      url=f'http://localhost/1.0/nlp/'
+                          f'{NlpApi.get_active_model_api(nlp_task=nlp_task).endpoint()}',
+                      json=expected_response_dict, status=200)
+
+        expected_response = GetActiveModelResponse(GenericResponse(200, "OK", json.dumps(expected_response_dict), None))
+        actual_response: GetActiveModelResponse = gg_sdk.get_active_model(nlp_task=nlp_task)
 
         assert actual_response == expected_response
 


### PR DESCRIPTION
Allows the sdk to call the getActiveModel endpoint set up in [this PR](https://bitbucket.org/graphgrid/graphgrid-boot-nlp/pull-requests/228/20-getactivemodel)