### PR TITLE
2.0 fix expires in

### DIFF
--- a/graphgrid_sdk/ggcore/session.py
+++ b/graphgrid_sdk/ggcore/session.py
@@ -44,7 +44,8 @@ class TokenFactory:
         if get_token_response.status_code == 200:
             self._token_tracker = TokenTracker(
                 get_token_response.access_token,
-                int(get_token_response.expires_in),  # cast expires_in to int
+                # cast expires_in to int
+                int(get_token_response.expires_in) * 1000,
                 get_time_in_ms()
             )
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -50,7 +50,7 @@ class TestTokenFactory(TestBootstrapBase):
         expiration.
         """
 
-        test_expiration_time_ms = 5_000  # expiration time in ms
+        test_expiration_time_s = 5  # expiration time in seconds
         test_token_after_expiry = "token-after-expiry"
 
         security_client = InternalSecurityClient(self._test_bootstrap_config)
@@ -59,7 +59,7 @@ class TestTokenFactory(TestBootstrapBase):
 
         json_body = {"access_token": TestBase.TEST_TOKEN,
                      "token_type": RequestAuthType.BEARER.value,
-                     "expires_in": str(test_expiration_time_ms),
+                     "expires_in": str(test_expiration_time_s),
                      "createdAt": "2022-04-01T19:48:47.647Z"}
 
         responses.add(responses.POST,
@@ -74,7 +74,7 @@ class TestTokenFactory(TestBootstrapBase):
         assert token_factory.is_token_expired() is False
 
         # sleep until expiry
-        time.sleep(test_expiration_time_ms // 1000)
+        time.sleep(test_expiration_time_s)
 
         # assert token has expired
         assert token_factory.is_token_expired() is True


### PR DESCRIPTION
Fix bug related to interpreting the `expires_in` field as milliseconds rather than seconds, meaning tokens expired after around 30 seconds.