### PR TITLE
2.0 nmt train pipeline

### DIFF
--- a/graphgrid_sdk/ggcore/nmt_train_pipeline.py
+++ b/graphgrid_sdk/ggcore/nmt_train_pipeline.py
@@ -1,0 +1,152 @@
+import math
+import time
+
+from graphgrid_sdk.ggcore.client import ConfigClient, NlpClient
+from graphgrid_sdk.ggcore.config import SdkBootstrapConfig
+from graphgrid_sdk.ggcore.sdk_messages import TrainRequestBody, PromoteModelResponse, NMTStatusResponse, \
+    GetActiveModelResponse, NMTTrainPipelineResponse
+
+
+def sigmoid(x):
+    return 1 / (1 + math.exp(-x))
+
+
+def evaluate_models(active_model: GetActiveModelResponse, new_model: NMTStatusResponse):
+    active_model_data = active_model.trainedModelData
+    if active_model_data.properties == new_model.properties:
+        # Properties match (note: order matters for lists)
+        # Now check if newer model has eval metrics
+        if new_model.evalAccuracy is not None \
+                and new_model.evalLoss is not None:
+            # Does the other model have eval metrics too?
+            if active_model_data.evalAccuracy is not None \
+                    and active_model_data.evalLoss is not None:
+                # Lower losses are preferred
+                loss_delta = sigmoid(active_model_data.evalLoss) - \
+                             sigmoid(new_model.evalLoss)
+                # Higher accuracies are preferred
+                acc_delta = -1 * (active_model_data.evalAccuracy - active_model_data.evalAccuracy)
+                # The more positive, the better the model
+                diff = loss_delta + acc_delta
+
+                if diff >= 0:
+                    # Update the selected model. Newer one is better
+                    return new_model
+                else:
+                    return active_model
+            else:
+                # Choose more recent model with eval metrics
+                return new_model
+
+        elif active_model_data.trainingAccuracy is not None \
+                and active_model_data.trainingLoss is not None \
+                and new_model.trainingAccuracy is not None \
+                and new_model.trainingLoss is not None:
+            # Lower losses are preferred
+            loss_delta = sigmoid(active_model_data.trainingLoss) - \
+                         sigmoid(new_model.trainingLoss)
+            # Higher accuracies are preferred
+            acc_delta = -1 * (
+                    active_model_data.trainingAccuracy - new_model.trainingAccuracy)
+            # The more positive, the better the model
+            diff = loss_delta + acc_delta
+
+            if diff >= 0:
+                # Update the selected model. Newer one is better
+                return new_model
+            else:
+                return active_model
+
+        elif active_model_data.evalLoss is not None \
+                and new_model.evalLoss is not None:
+            # This should only apply to translation
+            if new_model.evalLoss <= active_model_data.evalLoss:
+                return new_model
+            else:
+                return active_model
+
+        else:
+            # With no training or eval metrics choose more recent models
+            return new_model
+    else:
+        # Properties do not match. Choose the newer model
+        return new_model
+
+
+class NmtTrainPipeline:
+    _configuration: SdkBootstrapConfig
+
+    _config_client: ConfigClient
+    _nlp_client: NlpClient
+
+    def __init__(self, bootstrap_config: SdkBootstrapConfig):
+        self._configuration = bootstrap_config
+
+        self._setup_clients()
+
+    def _setup_clients(self):
+        """Setup low-level clients."""
+        self._config_client = ConfigClient(self._configuration)
+        self._nlp_client = NlpClient(self._configuration)
+
+    def nmt_train_pipeline(self, models_to_train, datasets, no_cache, gpu, autopromote, success_handler,
+                           failed_handler):
+
+        num_models = len(models_to_train)
+
+        train_request_bodies = []
+        for model in models_to_train:
+            train_request_bodies.append(
+                TrainRequestBody(model=model, datasets=datasets, no_cache=no_cache, gpu=gpu))
+
+        nmt_train_responses = []
+        for i in range(num_models):
+            nmt_train_responses.append(self._nlp_client.trigger_nmt(train_request_bodies[i]))
+
+        nmt_status_responses = []
+        for i in range(num_models):
+            nmt_status_responses.append(self._nlp_client.get_nmt_status(nmt_train_responses[i].dagRunId))
+
+        completed_runs = 0
+        while completed_runs < num_models:
+            print("...running dag...")
+            time.sleep(10)
+            for status in nmt_status_responses:
+                if status.state != "success" and status.state != "failed":
+                    status_idx = nmt_status_responses.index(status)
+                    nmt_status_responses[status_idx] = self._nlp_client.get_nmt_status(
+                        nmt_train_responses[status_idx].dagRunId)
+                    if nmt_status_responses[status_idx].state == "success" or \
+                            nmt_status_responses[status_idx].state == "failed":
+                        completed_runs = completed_runs + 1
+
+        for model_status in nmt_status_responses:
+            if model_status.state == "success" and success_handler is not None:
+                success_handler(model_status)
+            if model_status.state == "failed" and failed_handler is not None:
+                failed_handler(model_status)
+
+        print("Dag training/eval/model upload has finished.")
+
+        promoted_models = []
+        if autopromote:
+            for i in range(num_models):
+                status = nmt_status_responses[i]
+                if status.state == "success":
+                    selected_model = evaluate_models(self._nlp_client.get_active_model(models_to_train[i]),
+                                                     status)  # should be task name, is model type as written (i.e. promote_model takes "task name" (e.g. named_entity_recognition), but we are giving it "model type" (e.g. "named-entity-recognition")
+                    if selected_model == status:
+                        promote_model_response: PromoteModelResponse = \
+                            self._nlp_client.promote_model(status.savedModelName,
+                                                           "default")  # should be task name, is model type as written (i.e. promote_model takes "task name" (e.g. named_entity_recognition), but we are giving it "model type" (e.g. "named-entity-recognition")
+                        if promote_model_response.status_code == 200:
+                            print("Model has been promoted.")
+                            promoted_models.append(promote_model_response.modelName)
+                        else:
+                            print("Error promoting model: ", promote_model_response.exception)
+                    else:
+                        print("Model has not been promoted; currently active model has` greater accuracy")
+
+            print("Model promotion is complete.")
+
+        return NMTTrainPipelineResponse(nmt_status_responses, promoted_models)

--- a/graphgrid_sdk/ggcore/nmt_train_pipeline.py
+++ b/graphgrid_sdk/ggcore/nmt_train_pipeline.py
@@ -133,12 +133,10 @@ class NmtTrainPipeline:
             for i in range(num_models):
                 status = nmt_status_responses[i]
                 if status.state == "success":
-                    selected_model = evaluate_models(self._nlp_client.get_active_model(models_to_train[i]),
-                                                     status)  # should be task name, is model type as written (i.e. promote_model takes "task name" (e.g. named_entity_recognition), but we are giving it "model type" (e.g. "named-entity-recognition")
+                    selected_model = evaluate_models(self._nlp_client.get_active_model(models_to_train[i]), status)
                     if selected_model == status:
                         promote_model_response: PromoteModelResponse = \
-                            self._nlp_client.promote_model(status.savedModelName,
-                                                           "default")  # should be task name, is model type as written (i.e. promote_model takes "task name" (e.g. named_entity_recognition), but we are giving it "model type" (e.g. "named-entity-recognition")
+                            self._nlp_client.promote_model(status.savedModelName, "default")
                         if promote_model_response.status_code == 200:
                             print("Model has been promoted.")
                             promoted_models.append(promote_model_response.modelName)

--- a/graphgrid_sdk/ggcore/nmt_train_pipeline.py
+++ b/graphgrid_sdk/ggcore/nmt_train_pipeline.py
@@ -1,5 +1,6 @@
 import math
 import time
+import typing
 
 import requests
 
@@ -7,6 +8,7 @@ from graphgrid_sdk.ggcore.client import ConfigClient, NlpClient
 from graphgrid_sdk.ggcore.config import SdkBootstrapConfig
 from graphgrid_sdk.ggcore.sdk_messages import TrainRequestBody, PromoteModelResponse, NMTStatusResponse, \
     GetActiveModelResponse, NMTTrainPipelineResponse
+from graphgrid_sdk.ggcore.utils import NlpModel
 
 
 def sigmoid(x):
@@ -91,8 +93,13 @@ class NmtTrainPipeline:
         self._config_client = ConfigClient(self._configuration)
         self._nlp_client = NlpClient(self._configuration)
 
-    def nmt_train_pipeline(self, models_to_train, datasets, no_cache, gpu,
-                           autopromote, success_handler, failed_handler):
+    def nmt_train_pipeline(self, models_to_train: typing.List[NlpModel],
+                           datasets: typing.Union[str, list],
+                           no_cache: typing.Optional[bool],
+                           gpu: typing.Optional[bool],
+                           autopromote: bool,
+                           success_handler: typing.Optional[callable],
+                           failed_handler: typing.Optional[callable]):
 
         num_models = len(models_to_train)
 

--- a/graphgrid_sdk/ggcore/sdk_messages.py
+++ b/graphgrid_sdk/ggcore/sdk_messages.py
@@ -337,3 +337,10 @@ class GetActiveModelResponse(SdkServiceResponse):
             loaded = json.loads(generic_response.response)
             self.modelName = loaded.get('modelName')
             self.trainedModelData = TrainedModelData(**loaded.get('trainedModelData'))
+
+
+@dataclass
+class NMTTrainPipelineResponse:
+    """Define class representing a NMT train pipeline call response."""
+    modelStatusList: list
+    promotedModelList: list

--- a/graphgrid_sdk/ggsdk/sdk.py
+++ b/graphgrid_sdk/ggsdk/sdk.py
@@ -3,11 +3,13 @@ import typing
 
 from graphgrid_sdk.ggcore.config import SdkBootstrapConfig
 from graphgrid_sdk.ggcore.core import SdkCore
+from graphgrid_sdk.ggcore.nmt_train_pipeline import NmtTrainPipeline
 from graphgrid_sdk.ggcore.sdk_messages import TestApiResponse, \
     SaveDatasetResponse, GetDataResponse, PromoteModelResponse, \
-    DagRunResponse, NMTTrainResponse, NMTStatusResponse, TrainRequestBody, NMTTrainPipelineResponse
+    DagRunResponse, NMTTrainResponse, NMTStatusResponse, TrainRequestBody, \
+    NMTTrainPipelineResponse
+from graphgrid_sdk.ggcore.utils import NlpModel
 from graphgrid_sdk.ggsdk.bootstrap import bootstrap_config_from_file
-from graphgrid_sdk.ggcore.nmt_train_pipeline import NmtTrainPipeline
 
 
 class GraphGridSdk:
@@ -104,10 +106,14 @@ class GraphGridSdk:
         """
         return self._core.get_active_model(nlp_task)
 
-    def nmt_train_pipeline(self, models_to_train: list, datasets: typing.Union[str, list],
-                           no_cache: typing.Optional[bool], gpu: typing.Optional[bool],
-                           autopromote: bool, success_handler: typing.Optional[callable],
-                           failed_handler: typing.Optional[callable]) -> NMTTrainPipelineResponse:
+    def nmt_train_pipeline(self, models_to_train: typing.List[NlpModel],
+                           datasets: typing.Union[str, list],
+                           no_cache: typing.Optional[bool],
+                           gpu: typing.Optional[bool],
+                           autopromote: bool,
+                           success_handler: typing.Optional[callable],
+                           failed_handler: typing.Optional[
+                               callable]) -> NMTTrainPipelineResponse:
         """Call to start training pipeline: kicks off and monitors training for specified tasks, then promotes
 
         :param models_to_train: List of models to train.

--- a/graphgrid_sdk/ggsdk/sdk.py
+++ b/graphgrid_sdk/ggsdk/sdk.py
@@ -119,5 +119,6 @@ class GraphGridSdk:
         :param failed_handler: Optional callable to run on a failed training.
         """
         pipeline = NmtTrainPipeline(self._config)
-        return pipeline.nmt_train_pipeline(models_to_train, datasets, no_cache, gpu, autopromote,
-                                           success_handler, failed_handler)
+        return pipeline.nmt_train_pipeline(models_to_train, datasets, no_cache,
+                                           gpu, autopromote, success_handler,
+                                           failed_handler)

--- a/graphgrid_sdk/ggsdk/sdk.py
+++ b/graphgrid_sdk/ggsdk/sdk.py
@@ -5,8 +5,9 @@ from graphgrid_sdk.ggcore.config import SdkBootstrapConfig
 from graphgrid_sdk.ggcore.core import SdkCore
 from graphgrid_sdk.ggcore.sdk_messages import TestApiResponse, \
     SaveDatasetResponse, GetDataResponse, PromoteModelResponse, \
-    DagRunResponse, NMTTrainResponse, NMTStatusResponse, TrainRequestBody
+    DagRunResponse, NMTTrainResponse, NMTStatusResponse, TrainRequestBody, NMTTrainPipelineResponse
 from graphgrid_sdk.ggsdk.bootstrap import bootstrap_config_from_file
+from graphgrid_sdk.ggcore.nmt_train_pipeline import NmtTrainPipeline
 
 
 class GraphGridSdk:
@@ -102,3 +103,21 @@ class GraphGridSdk:
         :param nlp_task: The associated NLP task for the desired model
         """
         return self._core.get_active_model(nlp_task)
+
+    def nmt_train_pipeline(self, models_to_train: list, datasets: typing.Union[str, list],
+                           no_cache: typing.Optional[bool], gpu: typing.Optional[bool],
+                           autopromote: bool, success_handler: typing.Optional[callable],
+                           failed_handler: typing.Optional[callable]) -> NMTTrainPipelineResponse:
+        """Call to start training pipeline: kicks off and monitors training for specified tasks, then promotes
+
+        :param models_to_train: List of models to train.
+        :param datasets: Dataset(s) to train on.
+        :param no_cache: Flag to prevent caching (defaults to False)
+        :param gpu: Flag to enable GPU usage (defaults to False)
+        :param autopromote: Flag to enable automatic promotion on successfully trained models.
+        :param success_handler: Optional callable to run on a successful training.
+        :param failed_handler: Optional callable to run on a failed training.
+        """
+        pipeline = NmtTrainPipeline(self._config)
+        return pipeline.nmt_train_pipeline(models_to_train, datasets, no_cache, gpu, autopromote,
+                                           success_handler, failed_handler)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -416,6 +416,7 @@ class TestNMTTrainPipeline(TestSdkBase):
 
         class MockStatusResponse:
             state: str
+            status_code: int = 200
             savedModelName: str = "savedModelName"
 
         class MockPromoteResponse:

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -11,7 +11,7 @@ from graphgrid_sdk.ggcore.api import ConfigApi, NlpApi
 from graphgrid_sdk.ggcore.sdk_messages import TestApiResponse, \
     GenericResponse, SaveDatasetResponse, PromoteModelResponse, \
     GetDataResponse, DagRunResponse, NMTTrainResponse, NMTStatusResponse, \
-    TrainRequestBody, GetActiveModelResponse, TrainedModelData
+    TrainRequestBody, GetActiveModelResponse
 from graphgrid_sdk.ggcore.session import TokenTracker, TokenFactory
 from graphgrid_sdk.ggcore.utils import NlpModel
 from graphgrid_sdk.ggsdk import sdk

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -11,7 +11,7 @@ from graphgrid_sdk.ggcore.api import ConfigApi, NlpApi
 from graphgrid_sdk.ggcore.sdk_messages import TestApiResponse, \
     GenericResponse, SaveDatasetResponse, PromoteModelResponse, \
     GetDataResponse, DagRunResponse, NMTTrainResponse, NMTStatusResponse, \
-    TrainRequestBody, GetActiveModelResponse
+    TrainRequestBody, GetActiveModelResponse, TrainedModelData
 from graphgrid_sdk.ggcore.session import TokenTracker, TokenFactory
 from graphgrid_sdk.ggcore.utils import NlpModel
 from graphgrid_sdk.ggsdk import sdk
@@ -400,3 +400,64 @@ class TestSdkNMT(TestSdkBase):
             request_body=request_body)
 
         assert actual_response == expected_response
+
+
+class TestNMTTrainPipeline(TestSdkBase):
+    """Define test class for nmt_train_pipeline sdk call."""
+
+    @mock.patch('graphgrid_sdk.ggcore.nmt_train_pipeline.evaluate_models')
+    @mock.patch('graphgrid_sdk.ggcore.client.NlpClient.promote_model')
+    @mock.patch('graphgrid_sdk.ggcore.client.NlpClient.get_active_model')
+    @mock.patch('graphgrid_sdk.ggcore.client.NlpClient.get_nmt_status')
+    @mock.patch('graphgrid_sdk.ggcore.client.NlpClient.trigger_nmt')
+    def test_nmt_train_pipeline(self, mock_trigger_nmt, mock_get_nmt_status, mock_get_active_model, mock_promote_model,
+                                mock_evaluate_models):
+        """Test sdk test_nmt_train_pipeline call."""
+
+        class MockStatusResponse:
+            state: str
+            savedModelName: str = "savedModelName"
+
+        class MockPromoteResponse:
+            status_code: int = 200
+            modelName: str = "modelName"
+
+        mock_status_running_response = MockStatusResponse()
+        mock_status_running_response.state = "running"
+        mock_status_success_response = MockStatusResponse()
+        mock_status_success_response.state = "success"
+        mock_get_nmt_status.side_effect = [mock_status_running_response, mock_status_running_response,
+                                           mock_status_success_response, mock_status_success_response]
+
+        mock_evaluate_models.return_value = mock_status_success_response
+        mock_promote_model.return_value = MockPromoteResponse()
+
+        handler_calls = []
+
+        def mock_success_handler(status_result):
+            handler_calls.append("success")
+
+        def mock_failed_handler(status_result):
+            handler_calls.append("failed")
+
+        gg_sdk = GraphGridSdk(self._test_bootstrap_config)
+
+        models_to_train = ["some-model", "some-other-model"]
+        datasets = "path/to/saved/dataset"
+        no_cache = False
+        gpu = False
+        autopromote = True
+
+        result = gg_sdk.nmt_train_pipeline(models_to_train, datasets, no_cache, gpu, autopromote, mock_success_handler,
+                                        mock_failed_handler)
+
+        mock_trigger_nmt.assert_called()
+        mock_get_nmt_status.assert_called()
+        mock_get_active_model.assert_called()
+        mock_evaluate_models.assert_called()
+        mock_promote_model.assert_called()
+
+        self.assertEqual(handler_calls, ["success", "success"])
+
+        self.assertEqual(result.modelStatusList, [mock_status_success_response, mock_status_success_response])
+        self.assertEqual(result.promotedModelList, [MockPromoteResponse.modelName, MockPromoteResponse.modelName])


### PR DESCRIPTION
Built on [trainedModelData class PR](https://github.com/graphgrid/graphgrid-sdk-python/pull/23)

Starts training for models provided in `models_to_train`, monitors training, and promotes models whose training was successful and accuracy is better than the current model (determined by `evaluate_models`, which is used in NMT as well), as long as `autopromote` is set to `True`.

There is a place where this will break until there is model task/type alignment (when get_active_model is called)